### PR TITLE
Use dedicated user in php container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 COMPOSE_EXEC_PHP = docker-compose exec php
 COMPOSE_EXEC_CONSOLE = ${COMPOSE_EXEC_PHP} bin/console
 
+up:
+	docker-compose up -d
+
+docker-build:
+	docker-compose build
+
 composer-install:
 	${COMPOSE_EXEC_PHP} composer install
 
@@ -12,6 +18,9 @@ db-migrate:
 
 db-create:
 	${COMPOSE_EXEC_CONSOLE} doctrine:database:create
+
+db-update-schema:
+	${COMPOSE_EXEC_CONSOLE} doctrine:schema:update --force
 
 db-drop:
 	${COMPOSE_EXEC_CONSOLE} doctrine:database:drop --force

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -7,4 +7,4 @@ RUN apt-get install -y libpq-dev zlib1g-dev libicu-dev zip git \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-
+USER 1000


### PR DESCRIPTION
Hi!

It won't work in all cases, but for default linux/osx setup that should be sufficent.

Could you check that? Remember to remove your var/cache directory and rebuild docker image (`make docker-build` or just a `docker-compose build`).

Closes #3 
